### PR TITLE
fix(ci): switch to macos-11 (Big Sur) runner

### DIFF
--- a/.github/workflows/_prepare.yml
+++ b/.github/workflows/_prepare.yml
@@ -17,7 +17,7 @@ jobs:
   emacs-builder:
     # Use oldest version of macOS to ensure emacs-bulder binary is compatible
     # with later versions of macOS.
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Checkout build-emacs-for-macos repo
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ on:
         required: false
         default: ""
       os:
-        description: 'Runner OS ("macos-10.15" or "macos-11")'
+        description: 'Runner OS ("macos-11", "macos-12", or "macos-latest")'
         required: true
-        default: "macos-10.15"
+        default: "macos-11"
       test_build_name:
         description: "Test build name"
         required: false
@@ -45,7 +45,7 @@ jobs:
     needs: [prepare]
     uses: jimeh/emacs-builds/.github/workflows/_build.yml@main
     with:
-      os: macos-10.15
+      os: ${{ github.event.inputs.os }}
       git_ref: ${{ github.event.inputs.git_ref }}
       git_sha: ${{ github.event.inputs.git_sha }}
       build_args: ${{ github.event.inputs.builder_args }}

--- a/.github/workflows/nightly-emacs-28.yml
+++ b/.github/workflows/nightly-emacs-28.yml
@@ -21,7 +21,7 @@ jobs:
     needs: [prepare]
     uses: jimeh/emacs-builds/.github/workflows/_build.yml@main
     with:
-      os: macos-10.15
+      os: macos-11
       git_ref: emacs-28
       git_sha: ${{ github.event.inputs.git_sha }}
     secrets:

--- a/.github/workflows/nightly-master.yml
+++ b/.github/workflows/nightly-master.yml
@@ -21,7 +21,7 @@ jobs:
     needs: [prepare]
     uses: jimeh/emacs-builds/.github/workflows/_build.yml@main
     with:
-      os: macos-10.15
+      os: macos-11
       git_ref: master
       git_sha: ${{ github.event.inputs.git_sha }}
     secrets:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 ## System Requirements
 
-- macOS 10.15.x or later (uses Rosetta2 on Apple Silicon machines).
+- macOS 11.x (Big Sur) or later (uses Rosetta2 on Apple Silicon machines).
 - Xcode Command Line Tools for native compilation (Emacs 28.x and later).
 
 ## Installation
@@ -147,8 +147,8 @@ use the alias from the above example.
 ## Build Process
 
 Building Emacs is done using the [jimeh/build-emacs-for-macos][] build script,
-executed within a GitHub Actions [workflow][]. This is why macOS 10.15.x or
-later is required, as it's the oldest version of macOS available in GitHub
+executed within a GitHub Actions [workflow][]. This is why macOS 11.x (Big Sur)
+or later is required, as it's the oldest version of macOS available in GitHub
 Actions.
 
 [jimeh/build-emacs-for-macos]: https://github.com/jimeh/build-emacs-for-macos


### PR DESCRIPTION
The macos-10.15 runner is now deprecated and no longer usable. Hence all GitHub
Actions workflows using a macOS runner need to upgraded to macos-11.

As far as I know, this will have a knock-on effect of causing Emacs builds to
require macOS 11.x (Big Sur) or later from now on.