### PR TITLE
chore(workflows): update to macos-15 runners

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -63,8 +63,8 @@ jobs:
     needs: [prepare]
     with:
       builder_ref: ${{ needs.prepare.outputs.builder_sha }}
-      os: "macos-13"
-      build_os: "macos-13" # Only macos-13 and earlier are x86_64.
+      os: "macos-15-intel"
+      build_os: "macos-15-intel"
       artifact_prefix: "x86_64-"
       git_ref: ${{ inputs.git_ref }}
       git_sha: ${{ inputs.git_sha }}
@@ -88,7 +88,7 @@ jobs:
       needs.build_arm64.result != 'failure'
     with:
       builder_ref: ${{ needs.prepare.outputs.builder_sha }}
-      os: "macos-13" # Only macos-13 and earlier are x86_64.
+      os: "macos-15-intel"
       plan_artifact: x86_64-build-plan
       dmg_artifact: x86_64-dmg
 
@@ -103,8 +103,8 @@ jobs:
     needs: [prepare]
     with:
       builder_ref: ${{ needs.prepare.outputs.builder_sha }}
-      os: "macos-14"
-      build_os: "macos-14" # Only macos-14 and later are ARM64.
+      os: "macos-15"
+      build_os: "macos-15"
       artifact_prefix: "arm64-"
       git_ref: ${{ inputs.git_ref }}
       git_sha: ${{ inputs.git_sha }}
@@ -128,7 +128,7 @@ jobs:
       needs.build_x86_64.result != 'failure'
     with:
       builder_ref: ${{ needs.prepare.outputs.builder_sha }}
-      os: "macos-14" # Only macos-14 and later are ARM64.
+      os: "macos-15"
       plan_artifact: arm64-build-plan
       dmg_artifact: arm64-dmg
 

--- a/.github/workflows/_build_emacs.yml
+++ b/.github/workflows/_build_emacs.yml
@@ -12,12 +12,12 @@ on:
         description: GitHub Actions runner OS
         type: string
         required: false
-        default: "macos-13"
+        default: "macos-15"
       build_os:
         description: Target OS to build for
         type: string
         required: false
-        default: "macos-13"
+        default: "macos-15"
       artifact_prefix:
         description: Artifact prefix for build_os
         type: string

--- a/.github/workflows/_prepare.yml
+++ b/.github/workflows/_prepare.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   builder-sha:
-    runs-on: "macos-13"
+    runs-on: "macos-15"
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
       sha: ${{ steps.sha.outputs.sha }}
@@ -54,8 +54,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13 # Only macos-13 and earlier are x86_64.
-          - macos-14 # Only macos-14 and later are ARM64.
+          - macos-15
+          - macos-15-intel
     runs-on: ${{ matrix.os }}
     steps:
       - name: Cache emacs-builder (${{ runner.arch }})

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -15,7 +15,7 @@ on:
         description: GitHub Actions runner OS
         type: string
         required: false
-        default: "macos-13"
+        default: "macos-15"
       plan_artifact:
         description: Name of artifact containing a emacs-builder plan yaml file
         type: string


### PR DESCRIPTION
Upgrade from `macos-13` and `macos-14` runners to `macos-15` and 
`macos-15-intel` runners.

Previously we were still using `macos-13`, as the default free tier were
Intel-based. From macos-14 and later the default free tier is ARM-based.